### PR TITLE
Actualizar la API de descarga

### DIFF
--- a/admin-cfdi
+++ b/admin-cfdi
@@ -388,7 +388,6 @@ class Application(pygubu.TkApplication):
             descarga.connect(profile, rfc=data['rfc'], ciec=data['ciec'])
             docs = descarga.search(
                 facturas_emitidas=data['facturas_emitidas'],
-                type_search=1 * (data['uuid'] != ''),
                 uuid=data['uuid'],
                 rfc_emisor=data['rfc_emisor'],
                 año=data['año'],
@@ -432,9 +431,6 @@ class Application(pygubu.TkApplication):
         - type_invoice: La selección hecha en
           *Tipo de consulta*: 2 facturas recibidas,
           1 facturas emitidas
-        - type_search: La selección hecha en *Tipo
-          de búsqueda*: 0 por fecha,
-          1 por folio fiscal (UUID)
         - search_uuid: el valor llenado para *UUID*,
           es cadena vacía por omisión
         - search_rfc: el valor llenado en *RFC Emisor*,
@@ -489,7 +485,6 @@ class Application(pygubu.TkApplication):
         user = self.users_sat[current_user]
         data = {
             'facturas_emitidas': self._get('type_invoice'),
-            'type_search': opt,
             'rfc': user['user_sat'],
             'ciec': user['password'],
             'carpeta_destino': user['target_sat'],

--- a/admin-cfdi
+++ b/admin-cfdi
@@ -422,15 +422,16 @@ class Application(pygubu.TkApplication):
         y se regresa (False, {})
 
         Si las validaciones pasan, se construye un
-        diccionario ``data`` con estas llaves y valores:
+        diccionario ``data`` con estas llaves y valores
+        requeridos por la API de descarga:
 
         - user_sat: un diccionario con el
           RFC, la CIEC y la carpeta destino
           que se seleccionaron, con las llaves
           ``user_sat``, ``password`` y ``target_sat``.
-        - type_invoice: La selección hecha en
-          *Tipo de consulta*: 2 facturas recibidas,
-          1 facturas emitidas
+        - facturas_emitidas: True si la selección hecha en
+          *Tipo de consulta* es 1 facturas emitidas, False
+          si la selección es 2 facturas recibidas
         - search_uuid: el valor llenado para *UUID*,
           es cadena vacía por omisión
         - search_rfc: el valor llenado en *RFC Emisor*,
@@ -484,7 +485,7 @@ class Application(pygubu.TkApplication):
         search_day = self._get('search_day')
         user = self.users_sat[current_user]
         data = {
-            'facturas_emitidas': self._get('type_invoice'),
+            'facturas_emitidas': self._get('type_invoice') == 1,
             'rfc': user['user_sat'],
             'ciec': user['password'],
             'carpeta_destino': user['target_sat'],

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1771,7 +1771,6 @@ class DescargaSAT(object):
 
     def search(self,
         facturas_emitidas=False,
-        type_search=0,
         rfc='',
         ciec='',
         uuid='',
@@ -1792,7 +1791,7 @@ class DescargaSAT(object):
             browser.get(page_query)
             self.util.sleep(3)
             self.status('Buscando...')
-            if type_search == 1:
+            if uuid:
                 txt = browser.find_element_by_id(self.g.SAT['uuid'])
                 txt.click()
                 txt.send_keys(uuid)
@@ -1802,7 +1801,7 @@ class DescargaSAT(object):
                 opt.click()
                 self.util.sleep(3)
                 if rfc_emisor:
-                    if type_search == 1:
+                    if uuid:
                         txt = browser.find_element_by_id(self.g.SAT['receptor'])
                     else:
                         txt = browser.find_element_by_id(self.g.SAT['emisor'])

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1775,7 +1775,7 @@ class DescargaSAT(object):
         rfc_emisor='',
         año=None,
         mes=None,
-        día=None,
+        día='00',
         mes_completo_por_día=False):
         'Busca y regresa los resultados'
 

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1785,7 +1785,7 @@ class DescargaSAT(object):
             browser = self.browser
 
             page_query = self.g.SAT['page_receptor']
-            if facturas_emitidas == 1:
+            if facturas_emitidas:
                 page_query = self.g.SAT['page_emisor']
 
             browser.get(page_query)
@@ -1807,7 +1807,7 @@ class DescargaSAT(object):
                         txt = browser.find_element_by_id(self.g.SAT['emisor'])
                     txt.send_keys(rfc_emisor)
                 # Emitidas
-                if facturas_emitidas == 1:
+                if facturas_emitidas:
                     year = int(año)
                     month = int(mes)
                     day = int(día)
@@ -1893,7 +1893,7 @@ class DescargaSAT(object):
             #~ El mismo tiempo tanto para emitidas como recibidas
             self.util.sleep(sec)
             # Bug del SAT
-            if facturas_emitidas != 1 and día != '00':
+            if not facturas_emitidas and día != '00':
                 combo = browser.find_element_by_id(self.g.SAT['day'])
                 sb = combo.get_attribute('sb')
                 combo = browser.find_element_by_id(
@@ -1915,7 +1915,7 @@ class DescargaSAT(object):
                 self.util.sleep(2)
                 browser.find_element_by_id(self.g.SAT['submit']).click()
                 self.util.sleep(sec)
-            elif facturas_emitidas == 2 and mes_completo_por_día:
+            elif not facturas_emitidas and mes_completo_por_día:
                 return self._download_sat_month(año, mes, browser)
 
             try:

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1771,8 +1771,6 @@ class DescargaSAT(object):
 
     def search(self,
         facturas_emitidas=False,
-        rfc='',
-        ciec='',
         uuid='',
         rfc_emisor='',
         año=None,

--- a/admincfdi/tests/test_pyutil.py
+++ b/admincfdi/tests/test_pyutil.py
@@ -81,8 +81,7 @@ class DescargaSAT(unittest.TestCase):
         profile = webdriver.FirefoxProfile()
         descarga = DescargaSAT(status_callback=self.status)
         descarga.browser = MagicMock()
-        results = descarga.search(type_search=1, uuid='uuid',
-                                  día='00')
+        results = descarga.search(uuid='uuid', día='00')
         self.assertEqual(0, len(results))
 
     def test_search_facturas_emitidas(self):

--- a/admincfdi/tests/test_pyutil.py
+++ b/admincfdi/tests/test_pyutil.py
@@ -92,7 +92,7 @@ class DescargaSAT(unittest.TestCase):
         profile = webdriver.FirefoxProfile()
         descarga = DescargaSAT(status_callback=self.status)
         descarga.browser = MagicMock()
-        results = descarga.search(facturas_emitidas=1,
+        results = descarga.search(facturas_emitidas=True,
                     año=1, mes=1)
         self.assertEqual(0, len(results))
 
@@ -163,7 +163,7 @@ class DescargaSAT(unittest.TestCase):
         descarga = DescargaSAT(status_callback=self.status)
         descarga.browser = MagicMock()
         descarga._download_sat_month = Mock(return_value=[])
-        results = descarga.search(facturas_emitidas=2, día='00',
+        results = descarga.search(día='00',
                                   mes_completo_por_día=True)
         self.assertEqual(0, len(results))
 

--- a/descarga-cfdi
+++ b/descarga-cfdi
@@ -93,7 +93,6 @@ def main():
     try:
         descarga.connect(profile, rfc=rfc, ciec=pwd)
         docs = descarga.search(facturas_emitidas= args.facturas_emitidas,
-                type_search=1 * (args.uuid != ''),
                 uuid=args.uuid,
                 rfc_emisor=args.rfc_emisor,
                 año=args.año,

--- a/descarga-cfdi
+++ b/descarga-cfdi
@@ -47,8 +47,8 @@ def process_command_line_arguments():
     help = 'Descargar facturas emitidas. ' \
            'Por omisión se descargan facturas recibidas'
     parser.add_argument('--facturas-emitidas',
-                        action='store_const', const=1,
-                        help=help, default=2)
+                        action='store_const', const=True,
+                        help=help, default=False)
 
     help = 'UUID. Por omisión no se usa en la búsqueda. ' \
            'Esta opción tiene precedencia sobre las demás ' \

--- a/docs/devel.rst
+++ b/docs/devel.rst
@@ -157,7 +157,6 @@ utilizan los siguientes pasos:
    obtenida::
 
         docs = descarga.search(facturas_emitidas=facturas_emitidas,
-                type_search=1 * (uuid != ''),
                 uuid=uuid,
                 rfc_emisor=rfc_emisor,
                 año=año,
@@ -187,7 +186,6 @@ que son parte del proyecto::
     try:
         descarga.connect(profile, rfc=rfc, ciec=pwd)
         docs = descarga.search(facturas_emitidas= args.facturas_emitidas,
-                type_search=1 * (args.uuid != ''),
                 uuid=args.uuid,
                 rfc_emisor=args.rfc_emisor,
                 año=args.año,

--- a/functional_DescargaSAT.py
+++ b/functional_DescargaSAT.py
@@ -143,6 +143,29 @@ class DescargaSAT(unittest.TestCase):
             descarga.disconnect()
             self.assertEqual(expected, len(os.listdir(destino)))
 
+    def test_emitidas(self):
+        import os
+        import tempfile
+        from admincfdi.pyutil import DescargaSAT
+
+        def no_op(*args):
+            pass
+
+        seccion = self.config['emitidas']
+        año = seccion['año']
+        mes = seccion['mes']
+        expected = int(seccion['expected'])
+        descarga = DescargaSAT(status_callback=no_op,
+                               download_callback=no_op)
+        with tempfile.TemporaryDirectory() as tempdir:
+            destino = os.path.join(tempdir, 'cfdi-descarga')
+            profile = descarga.get_firefox_profile(destino)
+            descarga.connect(profile, rfc=self.rfc, ciec=self.ciec)
+            docs = descarga.search(año=año, mes=mes, día='00',
+                facturas_emitidas=1)
+            descarga.disconnect()
+            self.assertEqual(expected, len(docs))
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/functional_DescargaSAT.py
+++ b/functional_DescargaSAT.py
@@ -159,7 +159,7 @@ class DescargaSAT(unittest.TestCase):
             profile = descarga.get_firefox_profile(destino)
             descarga.connect(profile, rfc=self.rfc, ciec=self.ciec)
             docs = descarga.search(año=año, mes=mes, día='00',
-                facturas_emitidas=1)
+                facturas_emitidas=True)
             descarga.disconnect()
             self.assertEqual(expected, len(docs))
 

--- a/functional_DescargaSAT.py
+++ b/functional_DescargaSAT.py
@@ -40,7 +40,6 @@ class DescargaSAT(unittest.TestCase):
         profile = descarga.get_firefox_profile('destino')
         descarga.connect(profile, rfc=self.rfc, ciec=self.ciec)
         result = descarga.search(uuid=uuid,
-            type_search=1,
             día='00')
         descarga.disconnect()
         self.assertEqual(expected, len(result))
@@ -62,9 +61,7 @@ class DescargaSAT(unittest.TestCase):
             destino = os.path.join(tempdir, 'cfdi-descarga')
             profile = descarga.get_firefox_profile(destino)
             descarga.connect(profile, rfc=self.rfc, ciec=self.ciec)
-            docs = descarga.search(uuid=uuid,
-                type_search=1,
-                día='00')
+            docs = descarga.search(uuid=uuid, día='00')
             descarga.download(docs)
             descarga.disconnect()
             self.assertEqual(expected, len(os.listdir(destino)))


### PR DESCRIPTION
Se remueven tres parámetros de search(), se estandariza el uso de facturas_emitidas como booleano, y se agrega una prueba funcional para la descarga de facturas emitidas.
