### PR TITLE
Uso de explicit waits

### DIFF
--- a/admin-cfdi
+++ b/admin-cfdi
@@ -388,7 +388,6 @@ class Application(pygubu.TkApplication):
             descarga.connect(profile, rfc=data['rfc'], ciec=data['ciec'])
             docs = descarga.search(
                 facturas_emitidas=data['facturas_emitidas'],
-                type_search=1 * (data['uuid'] != ''),
                 uuid=data['uuid'],
                 rfc_emisor=data['rfc_emisor'],
                 año=data['año'],
@@ -432,9 +431,6 @@ class Application(pygubu.TkApplication):
         - type_invoice: La selección hecha en
           *Tipo de consulta*: 2 facturas recibidas,
           1 facturas emitidas
-        - type_search: La selección hecha en *Tipo
-          de búsqueda*: 0 por fecha,
-          1 por folio fiscal (UUID)
         - search_uuid: el valor llenado para *UUID*,
           es cadena vacía por omisión
         - search_rfc: el valor llenado en *RFC Emisor*,
@@ -489,7 +485,6 @@ class Application(pygubu.TkApplication):
         user = self.users_sat[current_user]
         data = {
             'facturas_emitidas': self._get('type_invoice'),
-            'type_search': opt,
             'rfc': user['user_sat'],
             'ciec': user['password'],
             'carpeta_destino': user['target_sat'],

--- a/admin-cfdi
+++ b/admin-cfdi
@@ -422,15 +422,16 @@ class Application(pygubu.TkApplication):
         y se regresa (False, {})
 
         Si las validaciones pasan, se construye un
-        diccionario ``data`` con estas llaves y valores:
+        diccionario ``data`` con estas llaves y valores
+        requeridos por la API de descarga:
 
         - user_sat: un diccionario con el
           RFC, la CIEC y la carpeta destino
           que se seleccionaron, con las llaves
           ``user_sat``, ``password`` y ``target_sat``.
-        - type_invoice: La selección hecha en
-          *Tipo de consulta*: 2 facturas recibidas,
-          1 facturas emitidas
+        - facturas_emitidas: True si la selección hecha en
+          *Tipo de consulta* es 1 facturas emitidas, False
+          si la selección es 2 facturas recibidas
         - search_uuid: el valor llenado para *UUID*,
           es cadena vacía por omisión
         - search_rfc: el valor llenado en *RFC Emisor*,
@@ -484,7 +485,7 @@ class Application(pygubu.TkApplication):
         search_day = self._get('search_day')
         user = self.users_sat[current_user]
         data = {
-            'facturas_emitidas': self._get('type_invoice'),
+            'facturas_emitidas': self._get('type_invoice') == 1,
             'rfc': user['user_sat'],
             'ciec': user['password'],
             'carpeta_destino': user['target_sat'],

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1771,7 +1771,6 @@ class DescargaSAT(object):
 
     def search(self,
         facturas_emitidas=False,
-        type_search=0,
         rfc='',
         ciec='',
         uuid='',
@@ -1792,7 +1791,7 @@ class DescargaSAT(object):
             browser.get(page_query)
             self.util.sleep(3)
             self.status('Buscando...')
-            if type_search == 1:
+            if uuid:
                 txt = browser.find_element_by_id(self.g.SAT['uuid'])
                 txt.click()
                 txt.send_keys(uuid)
@@ -1802,7 +1801,7 @@ class DescargaSAT(object):
                 opt.click()
                 self.util.sleep(3)
                 if rfc_emisor:
-                    if type_search == 1:
+                    if uuid:
                         txt = browser.find_element_by_id(self.g.SAT['receptor'])
                     else:
                         txt = browser.find_element_by_id(self.g.SAT['emisor'])

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1775,7 +1775,7 @@ class DescargaSAT(object):
         rfc_emisor='',
         año=None,
         mes=None,
-        día=None,
+        día='00',
         mes_completo_por_día=False):
         'Busca y regresa los resultados'
 

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1935,6 +1935,8 @@ class DescargaSAT(object):
             results_table = wait.until(EC.presence_of_element_located(
                 (By.ID, 'ctl00_MainContent_PnlResultados')))
             if results_table.is_displayed():
+                wait.until(EC.element_to_be_clickable(
+                    (By.NAME, self.g.SAT['download'])))
                 docs = browser.find_elements_by_name(self.g.SAT['download'])
                 return docs
             else:

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1919,8 +1919,9 @@ class DescargaSAT(object):
                         self.util.sleep()
 
             browser.find_element_by_id(self.g.SAT['submit']).click()
-            wait.until(EC.presence_of_element_located(
-                        (By.ID, 'ctl00_MainContent_UpnlResultados')))
+            wait.until(visibility_of_either(
+                (By.ID, "ctl00_MainContent_PnlResultados"),
+                (By.ID, 'ctl00_MainContent_PnlNoResultados')))
             # Bug del SAT
             if not facturas_emitidas and día != '00':
                 wait.until(EC.staleness_of(combo_day))
@@ -1947,14 +1948,16 @@ class DescargaSAT(object):
                 link = wait.until(EC.element_to_be_clickable(
                                     (By.LINK_TEXT, día)))
                 browser.find_element_by_id(self.g.SAT['submit']).click()
-                wait.until(EC.presence_of_element_located(
-                            (By.ID, 'ctl00_MainContent_UpnlResultados')))
+                wait.until(visibility_of_either(
+                    (By.ID, "ctl00_MainContent_PnlResultados"),
+                    (By.ID, 'ctl00_MainContent_PnlNoResultados')))
             elif not facturas_emitidas and mes_completo_por_día:
                 return self._download_sat_month(año, mes, browser)
 
-            results_table = wait.until(EC.presence_of_element_located(
-                (By.ID, 'ctl00_MainContent_PnlResultados')))
-            if results_table.is_displayed():
+            results = wait.until(visibility_of_either(
+                (By.ID, "ctl00_MainContent_PnlResultados"),
+                (By.ID, 'ctl00_MainContent_PnlNoResultados')))
+            if 'PnlResultados' in results.get_attribute('id'):
                 wait.until(EC.element_to_be_clickable(
                     (By.NAME, self.g.SAT['download'])))
                 docs = browser.find_elements_by_name(self.g.SAT['download'])

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1785,7 +1785,7 @@ class DescargaSAT(object):
             browser = self.browser
 
             page_query = self.g.SAT['page_receptor']
-            if facturas_emitidas == 1:
+            if facturas_emitidas:
                 page_query = self.g.SAT['page_emisor']
 
             browser.get(page_query)
@@ -1807,7 +1807,7 @@ class DescargaSAT(object):
                         txt = browser.find_element_by_id(self.g.SAT['emisor'])
                     txt.send_keys(rfc_emisor)
                 # Emitidas
-                if facturas_emitidas == 1:
+                if facturas_emitidas:
                     year = int(año)
                     month = int(mes)
                     day = int(día)
@@ -1893,7 +1893,7 @@ class DescargaSAT(object):
             #~ El mismo tiempo tanto para emitidas como recibidas
             self.util.sleep(sec)
             # Bug del SAT
-            if facturas_emitidas != 1 and día != '00':
+            if not facturas_emitidas and día != '00':
                 combo = browser.find_element_by_id(self.g.SAT['day'])
                 sb = combo.get_attribute('sb')
                 combo = browser.find_element_by_id(
@@ -1915,7 +1915,7 @@ class DescargaSAT(object):
                 self.util.sleep(2)
                 browser.find_element_by_id(self.g.SAT['submit']).click()
                 self.util.sleep(sec)
-            elif facturas_emitidas == 2 and mes_completo_por_día:
+            elif not facturas_emitidas and mes_completo_por_día:
                 return self._download_sat_month(año, mes, browser)
 
             try:

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1754,7 +1754,12 @@ class DescargaSAT(object):
         txt = browser.find_element_by_name(self.g.SAT['password'])
         txt.send_keys(ciec)
         txt.submit()
-        time.sleep(3)
+        wait = WebDriverWait(browser, 10)
+        wait.until(EC.title_contains('NetIQ Access'))
+        iframe = browser.find_element(By.ID, 'content')
+        browser.switch_to.frame(iframe)
+        wait.until(EC.text_to_be_present_in_element(
+            (By.CLASS_NAME, 'messagetext'), 'session has been authenticated'))
         self.status('Conectado...')
 
     def disconnect(self):
@@ -1790,7 +1795,8 @@ class DescargaSAT(object):
                 page_query = self.g.SAT['page_emisor']
 
             browser.get(page_query)
-            self.util.sleep(3)
+            wait = WebDriverWait(browser, 10)
+            wait.until(EC.title_contains('Buscar CFDI'))
             self.status('Buscando...')
             if uuid:
                 txt = browser.find_element_by_id(self.g.SAT['uuid'])
@@ -1800,12 +1806,13 @@ class DescargaSAT(object):
                 # Descargar por fecha
                 opt = browser.find_element_by_id(self.g.SAT['date'])
                 opt.click()
-                self.util.sleep(3)
+                if facturas_emitidas:
+                    txt = wait.until(EC.element_to_be_clickable(
+                                        (By.ID, self.g.SAT['receptor'])))
+                else:
+                    txt = wait.until(EC.element_to_be_clickable(
+                                        (By.ID, self.g.SAT['emisor'])))
                 if rfc_emisor:
-                    if uuid:
-                        txt = browser.find_element_by_id(self.g.SAT['receptor'])
-                    else:
-                        txt = browser.find_element_by_id(self.g.SAT['emisor'])
                     txt.send_keys(rfc_emisor)
                 # Emitidas
                 if facturas_emitidas:

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1963,7 +1963,7 @@ class DescargaSAT(object):
             results = wait.until(visibility_of_either(
                 (By.ID, "ctl00_MainContent_PnlResultados"),
                 (By.ID, 'ctl00_MainContent_PnlNoResultados')))
-            if 'PnlResultados' in results.get_attribute('id'):
+            if results.get_attribute('id') == 'ctl00_MainContent_PnlResultados':
                 wait.until(EC.element_to_be_clickable(
                     (By.NAME, self.g.SAT['download'])))
                 docs = browser.find_elements_by_name(self.g.SAT['download'])

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1688,6 +1688,26 @@ class CFDIPDF(object):
         return date.strftime('{}, %d de {} de %Y'.format(
             d[date.weekday()], m[date.month]))
 
+class visibility_of_either(object):
+    """ An expectation for checking that one of two elements,
+    located by locator 1 and locator2, is visible.
+    Visibility means that the element is not only
+    displayed but also has a height and width that is
+    greater than 0.
+    returns the WebElement that is visible.
+    """
+    def __init__(self, locator1, locator2):
+        self.locator1 = locator1
+        self.locator2 = locator2
+
+    def __call__(self, driver):
+        element1 = driver.find_element(*self.locator1)
+        element2 = driver.find_element(*self.locator2)
+        return _element_if_visible(element1) or \
+               _element_if_visible(element2)
+
+def _element_if_visible(element):
+    return element if element.is_displayed() else False
 
 class DescargaSAT(object):
 

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1924,25 +1924,17 @@ class DescargaSAT(object):
                 else:
                     link = browser.find_element_by_link_text(día)
                 link.click()
-                self.util.sleep(2)
+                link = wait.until(EC.element_to_be_clickable(
+                                    (By.LINK_TEXT, día)))
                 browser.find_element_by_id(self.g.SAT['submit']).click()
-                self.util.sleep(sec)
+                wait.until(EC.presence_of_element_located(
+                            (By.ID, 'ctl00_MainContent_UpnlResultados')))
             elif not facturas_emitidas and mes_completo_por_día:
                 return self._download_sat_month(año, mes, browser)
 
-            try:
-                found = True
-                content = browser.find_elements_by_class_name(
-                    self.g.SAT['subtitle'])
-                for c in content:
-                    if self.g.SAT['found'] in c.get_attribute('innerHTML') \
-                        and c.is_displayed():
-                        found = False
-                        break
-            except Exception as e:
-                print (str(e))
-
-            if found:
+            results_table = wait.until(EC.presence_of_element_located(
+                (By.ID, 'ctl00_MainContent_PnlResultados')))
+            if results_table.is_displayed():
                 docs = browser.find_elements_by_name(self.g.SAT['download'])
                 return docs
             else:

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1771,8 +1771,6 @@ class DescargaSAT(object):
 
     def search(self,
         facturas_emitidas=False,
-        rfc='',
-        ciec='',
         uuid='',
         rfc_emisor='',
         año=None,

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1859,20 +1859,22 @@ class DescargaSAT(object):
                     #~ combos = browser.find_elements_by_class_name(
                         #~ self.g.SAT['combos'])
                     #~ combos[0].click()
-                    combo = browser.find_element_by_id(self.g.SAT['year'])
+                    combo = wait.until(EC.presence_of_element_located(
+                                        (By.ID, self.g.SAT['year'])))
+                    sb = combo.get_attribute('sb')
                     combo = browser.find_element_by_id(
-                        'sbToggle_{}'.format(combo.get_attribute('sb')))
+                        'sbToggle_{}'.format(sb))
                     combo.click()
-                    self.util.sleep(2)
-                    link = browser.find_element_by_link_text(año)
+                    link = wait.until(EC.element_to_be_clickable(
+                                        (By.LINK_TEXT, año)))
                     link.click()
-                    self.util.sleep(2)
-                    combo = browser.find_element_by_id(self.g.SAT['month'])
+                    combo = wait.until(EC.presence_of_element_located(
+                                        (By.ID, self.g.SAT['month'])))
                     combo = browser.find_element_by_id(
                         'sbToggle_{}'.format(combo.get_attribute('sb')))
                     combo.click()
-                    self.util.sleep(2)
-                    link = browser.find_element_by_link_text(mes)
+                    link = wait.until(EC.element_to_be_clickable(
+                                        (By.LINK_TEXT, mes)))
                     link.click()
                     self.util.sleep(2)
                     if día != '00':
@@ -1897,9 +1899,8 @@ class DescargaSAT(object):
                         self.util.sleep()
 
             browser.find_element_by_id(self.g.SAT['submit']).click()
-            sec = 15
-            #~ El mismo tiempo tanto para emitidas como recibidas
-            self.util.sleep(sec)
+            wait.until(EC.presence_of_element_located(
+                        (By.ID, 'ctl00_MainContent_UpnlResultados')))
             # Bug del SAT
             if not facturas_emitidas and día != '00':
                 combo = browser.find_element_by_id(self.g.SAT['day'])
@@ -1908,6 +1909,8 @@ class DescargaSAT(object):
                     'sbToggle_{}'.format(sb))
                 combo.click()
                 self.util.sleep(2)
+                link = wait.until(EC.element_to_be_clickable(
+                                    (By.LINK_TEXT, día)))
                 if mes == día:
                     links = browser.find_elements_by_link_text(día)
                     for l in links:

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1918,7 +1918,10 @@ class DescargaSAT(object):
                         link.click()
                         self.util.sleep()
 
+            results_table = browser.find_element_by_id(
+                'ctl00_MainContent_PnlResultados')
             browser.find_element_by_id(self.g.SAT['submit']).click()
+            wait.until(EC.staleness_of(results_table))
             wait.until(visibility_of_either(
                 (By.ID, "ctl00_MainContent_PnlResultados"),
                 (By.ID, 'ctl00_MainContent_PnlNoResultados')))
@@ -1947,7 +1950,10 @@ class DescargaSAT(object):
                 link.click()
                 link = wait.until(EC.element_to_be_clickable(
                                     (By.LINK_TEXT, día)))
+                results_table = browser.find_element_by_id(
+                    'ctl00_MainContent_PnlResultados')
                 browser.find_element_by_id(self.g.SAT['submit']).click()
+                wait.until(EC.staleness_of(results_table))
                 wait.until(visibility_of_either(
                     (By.ID, "ctl00_MainContent_PnlResultados"),
                     (By.ID, 'ctl00_MainContent_PnlNoResultados')))

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1919,12 +1919,12 @@ class DescargaSAT(object):
                         self.util.sleep()
 
             results_table = browser.find_element_by_id(
-                'ctl00_MainContent_PnlResultados')
+                self.g.SAT['resultados'])
             browser.find_element_by_id(self.g.SAT['submit']).click()
             wait.until(EC.staleness_of(results_table))
             wait.until(visibility_of_either(
-                (By.ID, "ctl00_MainContent_PnlResultados"),
-                (By.ID, 'ctl00_MainContent_PnlNoResultados')))
+                (By.ID, self.g.SAT['resultados']),
+                (By.ID, self.g.SAT['noresultados'])))
             # Bug del SAT
             if not facturas_emitidas and día != '00':
                 wait.until(EC.staleness_of(combo_day))
@@ -1951,19 +1951,19 @@ class DescargaSAT(object):
                 link = wait.until(EC.element_to_be_clickable(
                                     (By.LINK_TEXT, día)))
                 results_table = browser.find_element_by_id(
-                    'ctl00_MainContent_PnlResultados')
+                    self.g.SAT['resultados'])
                 browser.find_element_by_id(self.g.SAT['submit']).click()
                 wait.until(EC.staleness_of(results_table))
                 wait.until(visibility_of_either(
-                    (By.ID, "ctl00_MainContent_PnlResultados"),
-                    (By.ID, 'ctl00_MainContent_PnlNoResultados')))
+                    (By.ID, self.g.SAT['resultados']),
+                    (By.ID, self.g.SAT['noresultados'])))
             elif not facturas_emitidas and mes_completo_por_día:
                 return self._download_sat_month(año, mes, browser)
 
             results = wait.until(visibility_of_either(
-                (By.ID, "ctl00_MainContent_PnlResultados"),
-                (By.ID, 'ctl00_MainContent_PnlNoResultados')))
-            if results.get_attribute('id') == 'ctl00_MainContent_PnlResultados':
+                (By.ID, self.g.SAT['resultados']),
+                (By.ID, self.g.SAT['noresultados'])))
+            if results.get_attribute('id') == self.g.SAT['resultados']:
                 wait.until(EC.element_to_be_clickable(
                     (By.NAME, self.g.SAT['download'])))
                 docs = browser.find_elements_by_name(self.g.SAT['download'])

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -36,6 +36,9 @@ from tkinter.filedialog import askopenfilename
 from tkinter import messagebox
 from requests import Request, Session
 from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from fpdf import FPDF
 from admincfdi.values import Global
 

--- a/admincfdi/pyutil.py
+++ b/admincfdi/pyutil.py
@@ -1878,8 +1878,8 @@ class DescargaSAT(object):
                     link.click()
                     self.util.sleep(2)
                     if día != '00':
-                        combo = browser.find_element_by_id(self.g.SAT['day'])
-                        sb = combo.get_attribute('sb')
+                        combo_day = browser.find_element_by_id(self.g.SAT['day'])
+                        sb = combo_day.get_attribute('sb')
                         combo = browser.find_element_by_id(
                             'sbToggle_{}'.format(sb))
                         combo.click()
@@ -1903,6 +1903,7 @@ class DescargaSAT(object):
                         (By.ID, 'ctl00_MainContent_UpnlResultados')))
             # Bug del SAT
             if not facturas_emitidas and día != '00':
+                wait.until(EC.staleness_of(combo_day))
                 combo = browser.find_element_by_id(self.g.SAT['day'])
                 sb = combo.get_attribute('sb')
                 combo = browser.find_element_by_id(

--- a/admincfdi/tests/test_pyutil.py
+++ b/admincfdi/tests/test_pyutil.py
@@ -81,8 +81,7 @@ class DescargaSAT(unittest.TestCase):
         profile = webdriver.FirefoxProfile()
         descarga = DescargaSAT(status_callback=self.status)
         descarga.browser = MagicMock()
-        results = descarga.search(type_search=1, uuid='uuid',
-                                  día='00')
+        results = descarga.search(uuid='uuid', día='00')
         self.assertEqual(0, len(results))
 
     def test_search_facturas_emitidas(self):

--- a/admincfdi/tests/test_pyutil.py
+++ b/admincfdi/tests/test_pyutil.py
@@ -13,6 +13,9 @@ class DescargaSAT(unittest.TestCase):
         pyutil.webdriver = Mock()
         pyutil.webdriver.FirefoxProfile = webdriver.FirefoxProfile
 
+        self.WebDriverWait = pyutil.WebDriverWait
+        pyutil.WebDriverWait = Mock()
+
         self.sleep = time.sleep
         time.sleep = Mock()
 
@@ -26,6 +29,7 @@ class DescargaSAT(unittest.TestCase):
         from admincfdi import pyutil
 
         pyutil.webdriver = self.webdriver
+        pyutil.WebDriverWait = self.WebDriverWait
         time.sleep = self.sleep
         del pyutil.print
 

--- a/admincfdi/tests/test_pyutil.py
+++ b/admincfdi/tests/test_pyutil.py
@@ -92,7 +92,7 @@ class DescargaSAT(unittest.TestCase):
         profile = webdriver.FirefoxProfile()
         descarga = DescargaSAT(status_callback=self.status)
         descarga.browser = MagicMock()
-        results = descarga.search(facturas_emitidas=1,
+        results = descarga.search(facturas_emitidas=True,
                     año=1, mes=1)
         self.assertEqual(0, len(results))
 
@@ -163,7 +163,7 @@ class DescargaSAT(unittest.TestCase):
         descarga = DescargaSAT(status_callback=self.status)
         descarga.browser = MagicMock()
         descarga._download_sat_month = Mock(return_value=[])
-        results = descarga.search(facturas_emitidas=2, día='00',
+        results = descarga.search(día='00',
                                   mes_completo_por_día=True)
         self.assertEqual(0, len(results))
 

--- a/admincfdi/values.py
+++ b/admincfdi/values.py
@@ -182,6 +182,8 @@ class Global(object):
         'page_cfdi': page_cfdi,
         'page_receptor': page_cfdi.format('ConsultaReceptor.aspx'),
         'page_emisor': page_cfdi.format('ConsultaEmisor.aspx'),
+        'resultados': 'ctl00_MainContent_PnlResultados',
+        'noresultados': 'ctl00_MainContent_PnlNoResultados',
     }
     frm_1 = '%(asctime)s - %(levelname)s - %(lineno)s - %(message)s'
     CONF_LOG = {

--- a/descarga-cfdi
+++ b/descarga-cfdi
@@ -93,7 +93,6 @@ def main():
     try:
         descarga.connect(profile, rfc=rfc, ciec=pwd)
         docs = descarga.search(facturas_emitidas= args.facturas_emitidas,
-                type_search=1 * (args.uuid != ''),
                 uuid=args.uuid,
                 rfc_emisor=args.rfc_emisor,
                 año=args.año,

--- a/descarga-cfdi
+++ b/descarga-cfdi
@@ -47,8 +47,8 @@ def process_command_line_arguments():
     help = 'Descargar facturas emitidas. ' \
            'Por omisión se descargan facturas recibidas'
     parser.add_argument('--facturas-emitidas',
-                        action='store_const', const=1,
-                        help=help, default=2)
+                        action='store_const', const=True,
+                        help=help, default=False)
 
     help = 'UUID. Por omisión no se usa en la búsqueda. ' \
            'Esta opción tiene precedencia sobre las demás ' \

--- a/docs/devel.rst
+++ b/docs/devel.rst
@@ -157,7 +157,6 @@ utilizan los siguientes pasos:
    obtenida::
 
         docs = descarga.search(facturas_emitidas=facturas_emitidas,
-                type_search=1 * (uuid != ''),
                 uuid=uuid,
                 rfc_emisor=rfc_emisor,
                 año=año,
@@ -187,7 +186,6 @@ que son parte del proyecto::
     try:
         descarga.connect(profile, rfc=rfc, ciec=pwd)
         docs = descarga.search(facturas_emitidas= args.facturas_emitidas,
-                type_search=1 * (args.uuid != ''),
                 uuid=args.uuid,
                 rfc_emisor=args.rfc_emisor,
                 año=args.año,

--- a/functional_DescargaSAT.py
+++ b/functional_DescargaSAT.py
@@ -143,6 +143,29 @@ class DescargaSAT(unittest.TestCase):
             descarga.disconnect()
             self.assertEqual(expected, len(os.listdir(destino)))
 
+    def test_emitidas(self):
+        import os
+        import tempfile
+        from admincfdi.pyutil import DescargaSAT
+
+        def no_op(*args):
+            pass
+
+        seccion = self.config['emitidas']
+        año = seccion['año']
+        mes = seccion['mes']
+        expected = int(seccion['expected'])
+        descarga = DescargaSAT(status_callback=no_op,
+                               download_callback=no_op)
+        with tempfile.TemporaryDirectory() as tempdir:
+            destino = os.path.join(tempdir, 'cfdi-descarga')
+            profile = descarga.get_firefox_profile(destino)
+            descarga.connect(profile, rfc=self.rfc, ciec=self.ciec)
+            docs = descarga.search(año=año, mes=mes, día='00',
+                facturas_emitidas=1)
+            descarga.disconnect()
+            self.assertEqual(expected, len(docs))
+
 
 if __name__ == '__main__':
 	unittest.main()

--- a/functional_DescargaSAT.py
+++ b/functional_DescargaSAT.py
@@ -159,7 +159,7 @@ class DescargaSAT(unittest.TestCase):
             profile = descarga.get_firefox_profile(destino)
             descarga.connect(profile, rfc=self.rfc, ciec=self.ciec)
             docs = descarga.search(año=año, mes=mes, día='00',
-                facturas_emitidas=1)
+                facturas_emitidas=True)
             descarga.disconnect()
             self.assertEqual(expected, len(docs))
 

--- a/functional_DescargaSAT.py
+++ b/functional_DescargaSAT.py
@@ -40,7 +40,6 @@ class DescargaSAT(unittest.TestCase):
         profile = descarga.get_firefox_profile('destino')
         descarga.connect(profile, rfc=self.rfc, ciec=self.ciec)
         result = descarga.search(uuid=uuid,
-            type_search=1,
             día='00')
         descarga.disconnect()
         self.assertEqual(expected, len(result))
@@ -62,9 +61,7 @@ class DescargaSAT(unittest.TestCase):
             destino = os.path.join(tempdir, 'cfdi-descarga')
             profile = descarga.get_firefox_profile(destino)
             descarga.connect(profile, rfc=self.rfc, ciec=self.ciec)
-            docs = descarga.search(uuid=uuid,
-                type_search=1,
-                día='00')
+            docs = descarga.search(uuid=uuid, día='00')
             descarga.download(docs)
             descarga.disconnect()
             self.assertEqual(expected, len(os.listdir(destino)))


### PR DESCRIPTION
Se agregan explicit waits en la descarga de CFDIs.  Funcionan muy bien y sí se vuelve más ágil la navegación, pero hay que ir agregando caso por caso y confirmar el resultado. Se van a agregar más commits conforme pasen las pruebas.
