### PR TITLE
Fix - admin-cfdi.pyw

### DIFF
--- a/admin-cfdi.pyw
+++ b/admin-cfdi.pyw
@@ -3,4 +3,4 @@ import os.path
 
 
 ac_path = os.path.join(sys.path[0], "admin-cfdi")
-exec(open(ac_path).read())
+exec(open(ac_path, encoding='utf-8').read())


### PR DESCRIPTION
Para poder correr con doble click, sin abrir una consola de comandos. También para correr desde la consola equivalente a `py admin-cfdi`
